### PR TITLE
Match v3 api for recently played champions

### DIFF
--- a/lib/lol_buddy/riot_api/riot_api.ex
+++ b/lib/lol_buddy/riot_api/riot_api.ex
@@ -150,7 +150,6 @@ defmodule LolBuddy.RiotApi.Api do
   def recent_champions(account_id, region) do
     fetch_recent_champions(account_id, region)
     ~>> Map.get("matches")
-    |>  IO.inspect
     |>  extract_most_played()
     |>  OK.success
   end

--- a/test/riot_api/riot_api_test.exs
+++ b/test/riot_api/riot_api_test.exs
@@ -1,0 +1,40 @@
+defmodule LolBuddyRiotApi.ApiTest do
+  require LolBuddy.RiotApi.Api
+  use ExUnit.Case, async: true
+
+  test "correct champions are extracted from matches" do
+    matches =
+      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played(matches)
+    assert Enum.member?(most_played, "Jax")
+    assert Enum.member?(most_played, "Sona")
+    assert Enum.member?(most_played, "Tristana")
+    assert Enum.count(most_played) == 3
+  end
+
+  test "draws still return at most 3 champions" do
+    matches =
+      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played(matches)
+    assert Enum.count(most_played) == 3
+  end
+
+  test "less than 3 champions in matches still finds most played" do
+    matches =
+      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played(matches)
+    assert Enum.member?(most_played, "Jax")
+    assert Enum.count(most_played) == 1
+  end
+end


### PR DESCRIPTION
Added and replaced the previous mastery based most played champion selection, with a most played champions based on recent 20 matches. Speed definitely seems sufficiently fast for this to be viable. Pipeline in function recent_champions/2 may be possible to tidy up slightly.