### PR TITLE
Unranked matching

### DIFF
--- a/lib/lol_buddy/players/matching.ex
+++ b/lib/lol_buddy/players/matching.ex
@@ -185,14 +185,30 @@ defmodule LolBuddy.Players.Matching do
 
   defp tier_to_int(tier) do
     case tier do
-      "BRONZE"     -> 1
-      "UNRANKED"   -> 2 # Riot treats unrankeds like silvers
-      "SILVER"     -> 2
-      "GOLD"       -> 3
-      "PLATINUM"   -> 4
-      "DIAMOND"    -> 5
-      "MASTER"     -> 6
-      "CHALLENGER" -> 7
+      "BRONZE" ->
+        1
+
+      # Riot treats unrankeds like silvers
+      "UNRANKED" ->
+        2
+
+      "SILVER" ->
+        2
+
+      "GOLD" ->
+        3
+
+      "PLATINUM" ->
+        4
+
+      "DIAMOND" ->
+        5
+
+      "MASTER" ->
+        6
+
+      "CHALLENGER" ->
+        7
     end
   end
 end

--- a/test/players/matching_test.exs
+++ b/test/players/matching_test.exs
@@ -172,6 +172,22 @@ defmodule LolBuddy.MatchingTest do
     assert Matching.tier_compatible?(platinum1, gold5)
   end
 
+  test "plat and unranked are compatible" do
+    platinum1 = %{type: "RANKED_SOLO_5x5", tier: "PLATINUM", rank: 1}
+    unranked = %{type: "RANKED_SOLO_5x5", tier: "UNRANKED", rank: 5}
+    refute Matching.tier_compatible?(platinum1, unranked)
+  end
+
+  test "unranked is compatible with bronze, silver and gold" do
+    bronze = %{type: "RANKED_SOLO_5x5", tier: "BRONZE", rank: 1}
+    silver = %{type: "RANKED_SOLO_5x5", tier: "SILVER", rank: 1}
+    gold = %{type: "RANKED_SOLO_5x5", tier: "GOLD", rank: 1}
+    unranked = %{type: "RANKED_SOLO_5x5", tier: "UNRANKED", rank: 5}
+    assert Matching.tier_compatible?(unranked, bronze)
+    assert Matching.tier_compatible?(unranked, silver)
+    assert Matching.tier_compatible?(unranked, gold)
+  end
+
   test "diamond5 and plat3 are compatible" do
     platinum3 = %{type: "RANKED_SOLO_5x5", tier: "PLATINUM", rank: 3}
     diamond5 = %{type: "RANKED_SOLO_5x5", tier: "DIAMOND", rank: 5}


### PR DESCRIPTION
Allow unranked players to be matched by treating them like silver players - This assumes that players labelled "unranked" are not just eg. diamond players in their placement matches. The riot api module should however take care of this. Closes #47 