### PR TITLE
Treat challenger players like master for matching

### DIFF
--- a/lib/lol_buddy/players/matching.ex
+++ b/lib/lol_buddy/players/matching.ex
@@ -85,10 +85,8 @@ defmodule LolBuddy.Players.Matching do
     lr = get_rank(low)
 
     cond do
-      ht == "CHALLENGER" ->
-        false
-
-      ht == "MASTER" ->
+      # master and challenger have equal restrictions
+      ht == "MASTER" || ht == "CHALLENGER" ->
         lr in 1..3
 
       # now we may can assume ht is diamond
@@ -131,11 +129,8 @@ defmodule LolBuddy.Players.Matching do
   def tier_compatible?(league1, league2) do
     {h, l} = sort_leagues(league1, league2)
     tier_diff = tier_to_int(h.tier) - tier_to_int(l.tier)
-    # challenger's may only walk alone
-    cond do
-      h.tier == "CHALLENGER" ->
-        false
 
+    cond do
       # special handling for d1 as it cannot queue with its entire league
       h.tier == "DIAMOND" && get_rank(h) == 1 ->
         rank_compatible?(h, l)
@@ -204,7 +199,7 @@ defmodule LolBuddy.Players.Matching do
         6
 
       "CHALLENGER" ->
-        7
+        6
     end
   end
 

--- a/test/players/matching_test.exs
+++ b/test/players/matching_test.exs
@@ -273,9 +273,27 @@ defmodule LolBuddy.MatchingTest do
     refute Matching.tier_compatible?(master, diamond4)
   end
 
-  test "challenger is always incompatible" do
+  test "challenger may queue with challenger" do
     challenger = %{type: "RANKED_SOLO_5x5", tier: "CHALLENGER", rank: 1}
-    refute Matching.tier_compatible?(challenger, challenger)
+    assert Matching.tier_compatible?(challenger, challenger)
+  end
+
+  test "challenger may queue with master" do
+    challenger = %{type: "RANKED_SOLO_5x5", tier: "CHALLENGER", rank: 1}
+    master = %{type: "RANKED_SOLO_5x5", tier: "MASTER", rank: 1}
+    assert Matching.tier_compatible?(challenger, master)
+  end
+
+  test "challenger may queue with diamond 3" do
+    challenger = %{type: "RANKED_SOLO_5x5", tier: "CHALLENGER", rank: 1}
+    diamond3 = %{type: "RANKED_SOLO_5x5", tier: "DIAMOND", rank: 3}
+    assert Matching.tier_compatible?(challenger, diamond3)
+  end
+
+  test "challenger may not queue with diamond 3" do
+    challenger = %{type: "RANKED_SOLO_5x5", tier: "CHALLENGER", rank: 1}
+    diamond4 = %{type: "RANKED_SOLO_5x5", tier: "DIAMOND", rank: 4}
+    refute Matching.tier_compatible?(challenger, diamond4)
   end
 
   test "gold with no rank is compatible with plat/gold/silver" do


### PR DESCRIPTION
Per patch 8.1 challenger players are treated equal to master players for matching.
Closes #59 