### PR TITLE
remove auto_revision from edeliver

### DIFF
--- a/.deliver/config
+++ b/.deliver/config
@@ -7,7 +7,9 @@ BUILD_AT="/home/worker/app_build"
 PRODUCTION_HOSTS="buddy.gg"
 PRODUCTION_USER="worker"
 DELIVER_TO="/home/worker/app_release"
-AUTO_VERSION=revision
+# We manually increment versions in mix.exs
+# using semantic versioning instead.
+# AUTO_VERSION=revision
 
 pre_erlang_get_and_update_deps() {
   # copy it on the build host to the build directory when building


### PR DESCRIPTION
We will instead use semantic versioning in mix.exs which we will bump
upon each merge to master. To map revisions to commits we will use tags,
exactly like we are already doing. Closes #64 